### PR TITLE
Gravatar-4: Closes #4

### DIFF
--- a/gravatar.install
+++ b/gravatar.install
@@ -14,18 +14,6 @@ function gravatar_schema() {
 }
 
 /**
- * Implements hook_uninstall().
- */
-function gravatar_uninstall() {
-  // Remove variables.
-  backdrop_load('module', 'gravatar');
-  $variables = array_keys(gravatar_variables());
-  foreach ($variables as $variable) {
-    variable_del($variable);
-  }
-}
-
-/**
  * Checks requirements for Gravatar.
  */
 function gravatar_check_requirements() {


### PR DESCRIPTION
Remove unnecessary hook_uninstall

The hook_uninstall function used to delete the remaining variables, but
now we are using Configuration Management. Now, when you uninstall a
module, the associated config .json files are deleted by Backdrop!
